### PR TITLE
Update to work with SUPEE-6788

### DIFF
--- a/src/app/code/community/WeCode/PromotionSchedule/controllers/Adminhtml/Promotionschedule/IndexController.php
+++ b/src/app/code/community/WeCode/PromotionSchedule/controllers/Adminhtml/Promotionschedule/IndexController.php
@@ -5,7 +5,7 @@
  * Why:  
  */
 
-class WeCode_PromotionSchedule_Adminhtml_IndexController extends Mage_Adminhtml_Controller_Action {
+class WeCode_PromotionSchedule_Adminhtml_Promotionschedule_IndexController extends Mage_Adminhtml_Controller_Action {
 
     public function indexAction()
     {

--- a/src/app/code/community/WeCode/PromotionSchedule/etc/adminhtml.xml
+++ b/src/app/code/community/WeCode/PromotionSchedule/etc/adminhtml.xml
@@ -12,12 +12,12 @@
                         <list module="wecode_promotionschedule">
                             <title>View Scheduled Promotions</title>
                             <sort_order>10</sort_order>
-                            <action>promotionschedule/index/index</action>
+                            <action>adminhtml/promotionschedule_index/index</action>
                         </list>
                         <new module="wecode_promotionschedule">
                             <title>New Promotion Schedule</title>
                             <sort_order>20</sort_order>
-                            <action>promotionschedule/index/new</action>
+                            <action>adminhtml/promotionschedule_index/new</action>
                         </new>
                     </children>
                 </promotionschedule_group>

--- a/src/app/code/community/WeCode/PromotionSchedule/etc/config.xml
+++ b/src/app/code/community/WeCode/PromotionSchedule/etc/config.xml
@@ -40,13 +40,13 @@
     </global>
     <admin>
         <routers>
-            <list>
-                <use>admin</use>
+            <adminhtml>
                 <args>
-                    <frontName>promotionschedule</frontName>
-                    <module>WeCode_PromotionSchedule_Adminhtml</module>
+                    <modules>
+                        <promotionschedule after="Mage_Adminhtml">WeCode_PromotionSchedule_Adminhtml</promotionschedule>
+                    </modules>
                 </args>
-            </list>
+            </adminhtml>
         </routers>
     </admin>
     <crontab>


### PR DESCRIPTION
Hi @alvinnguyen,

For SUPEE-6788 Magento update security compatibility for admin routers. I can see you have old version defining routers on Admin.

This commit will make the extension still works fine even after the SUPEE-6788 applied and enable.

Cheers,
Dimas
